### PR TITLE
fix: open binary file in read only mode when write=False

### DIFF
--- a/suite2p/io/binary.py
+++ b/suite2p/io/binary.py
@@ -38,7 +38,10 @@ class BinaryFile:
         elif not write:
             n_frames = self.n_frames
         shape = (n_frames, self.Ly, self.Lx)
-        mode = "w+" if write else "r+"
+        if write:
+            mode = "r+" if os.path.exists(self.filename) else "w+"
+        else:
+            mode = "r"
         self.file = np.memmap(self.filename, mode=mode, dtype=self.dtype, shape=shape)
         self._index = 0
         self._can_read = True

--- a/suite2p/io/binary.py
+++ b/suite2p/io/binary.py
@@ -13,7 +13,7 @@ import numpy as np
 class BinaryFile:
 
     def __init__(self, Ly: int, Lx: int, filename: str, n_frames: int = None,
-                 dtype: str = "int16"):
+                 dtype: str = "int16", write=False):
         """
         Creates/Opens a Suite2p BinaryFile for reading and/or writing image data that acts like numpy array
 
@@ -25,14 +25,21 @@ class BinaryFile:
             The width of each frame
         filename: str
             The filename of the file to read from or write to
+        n_frames : int, optional
+            Number of frames. Required when creating a new file for writing.
+            Inferred from file size when reading.
+        dtype : str, optional (default "int16")
+            Data type of each pixel value.
+        write : bool, optional (default False)
+            If True, open the file for reading and writing. If False, open read-only.
         """
         self.Ly = Ly
         self.Lx = Lx
         self.filename = filename
         self.dtype = dtype
-        write = (not os.path.exists(self.filename))
+        self.write = write
 
-        if write and n_frames is None:
+        if write and n_frames is None and not os.path.exists(self.filename):
             raise ValueError(
                 "need to provide number of frames n_frames when writing file")
         elif not write:

--- a/suite2p/io/binary.py
+++ b/suite2p/io/binary.py
@@ -39,12 +39,11 @@ class BinaryFile:
         self.dtype = dtype
         self.write = write
 
-        if write:
-            if n_frames is None and not os.path.exists(self.filename):
-                raise ValueError(
-                    "need to provide number of frames n_frames when writing file")
-            else:
-                n_frames = self.n_frames
+        if write and n_frames is None and not os.path.exists(self.filename):
+            raise ValueError(
+                "need to provide number of frames n_frames when writing file")
+        elif write and n_frames is None and os.path.exists(self.filename):
+            n_frames = self.n_frames
         elif not write:
             n_frames = self.n_frames
         shape = (n_frames, self.Ly, self.Lx)

--- a/suite2p/io/binary.py
+++ b/suite2p/io/binary.py
@@ -39,9 +39,12 @@ class BinaryFile:
         self.dtype = dtype
         self.write = write
 
-        if write and n_frames is None and not os.path.exists(self.filename):
-            raise ValueError(
-                "need to provide number of frames n_frames when writing file")
+        if write:
+            if n_frames is None and not os.path.exists(self.filename):
+                raise ValueError(
+                    "need to provide number of frames n_frames when writing file")
+            else:
+                n_frames = self.n_frames
         elif not write:
             n_frames = self.n_frames
         shape = (n_frames, self.Ly, self.Lx)

--- a/suite2p/io/binary.py
+++ b/suite2p/io/binary.py
@@ -31,19 +31,22 @@ class BinaryFile:
         dtype : str, optional (default "int16")
             Data type of each pixel value.
         write : bool, optional (default False)
+            If not specified, and the file does not exist, automatically set to True.
             If True, open the file for reading and writing. If False, open read-only.
         """
         self.Ly = Ly
         self.Lx = Lx
         self.filename = filename
         self.dtype = dtype
-        self.write = write
+        exists = os.path.exists(self.filename)
+        write = write or not exists
 
-        if write and n_frames is None and not os.path.exists(self.filename):
-            raise ValueError(
-                "need to provide number of frames n_frames when writing file")
-        elif write and n_frames is None and os.path.exists(self.filename):
-            n_frames = self.n_frames
+        if write and n_frames is None:
+            if not exists:
+                raise ValueError(
+                    "need to provide number of frames n_frames when writing file")
+            else:
+                n_frames = self.n_frames
         elif not write:
             n_frames = self.n_frames
         shape = (n_frames, self.Ly, self.Lx)

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -339,10 +339,10 @@ def run_plane(ops, ops_path=None, stat=None):
     twoc = ops["nchannels"] > 1
     with io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file, n_frames=n_frames, write=True) \
             if raw else null as f_raw, \
-         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file, n_frames=n_frames, write=True) as f_reg, \
+         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file, n_frames=n_frames) as f_reg, \
          io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file_chan2, n_frames=n_frames, write=True) \
             if raw and twoc else null as f_raw_chan2,\
-         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file_chan2, n_frames=n_frames, write=True) \
+         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file_chan2, n_frames=n_frames) \
             if twoc else null as f_reg_chan2:
 
         ops = pipeline(f_reg, f_raw, f_reg_chan2, f_raw_chan2, run_registration, ops,

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -337,7 +337,7 @@ def run_plane(ops, ops_path=None, stat=None):
 
     null = contextlib.nullcontext()
     twoc = ops["nchannels"] > 1
-    with io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file, n_frames=n_frames) \
+    with io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file, n_frames=n_frames, write=True) \
             if raw else null as f_raw, \
          io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file, n_frames=n_frames) as f_reg, \
          io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file_chan2, n_frames=n_frames) \

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -339,10 +339,10 @@ def run_plane(ops, ops_path=None, stat=None):
     twoc = ops["nchannels"] > 1
     with io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file, n_frames=n_frames, write=True) \
             if raw else null as f_raw, \
-         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file, n_frames=n_frames) as f_reg, \
-         io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file_chan2, n_frames=n_frames) \
+         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file, n_frames=n_frames, write=True) as f_reg, \
+         io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file_chan2, n_frames=n_frames, write=True) \
             if raw and twoc else null as f_raw_chan2,\
-         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file_chan2, n_frames=n_frames) \
+         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file_chan2, n_frames=n_frames, write=True) \
             if twoc else null as f_reg_chan2:
 
         ops = pipeline(f_reg, f_raw, f_reg_chan2, f_raw_chan2, run_registration, ops,


### PR DESCRIPTION
# Description

A bug was discovered when migrating suite2p tools to v3. Inputs can only be read-only with the IDEAS CLI tool runner, however suite2p binary files were being opened in `r+` mode, even when `write=False` is specified in the binary file constructor. 

This logic has been changed to be consistent with the latest version of this binary file class [in the original suite2p repo](https://github.com/MouseLand/suite2p/blob/a156b313e3d1b042383b31dd45b2ee180e0530a5/suite2p/io/binary.py#L14)

# Testing

Tested in this pr: https://github.com/inscopix/ideas-toolbox-suite2p/pull/4