### PR TITLE
It 1671 fix multiplane isxd binary conversion

### DIFF
--- a/suite2p/io/isxd.py
+++ b/suite2p/io/isxd.py
@@ -43,8 +43,9 @@ def isxd_to_binary(ops):
 
     for ifile, fname in enumerate(file_list):
         f = isx.Movie.read(fname)
-        nplanes = 1  #f.shape[1]
-        nchannels = 1  #f.shape[2]
+        # The following two lines break multiplane support
+        # nplanes = 1  #f.shape[1]
+        # nchannels = 1  #f.shape[2]
         nframes = f.timing.num_samples
         iblocks = np.arange(0, nframes, ops1[0]["batch_size"])
         if iblocks[-1] < nframes:

--- a/suite2p/io/isxd.py
+++ b/suite2p/io/isxd.py
@@ -34,27 +34,26 @@ def isxd_to_binary(ops):
     # the following should be taken from the metadata and not needed but the files are initialized before...
     nplanes = ops1[0]["nplanes"]
     nchannels = ops1[0]["nchannels"]
-    ncp = nplanes * nchannels
     nfunc = ops1[0]["functional_chan"] - 1 if nchannels > 1 else 0
+
+    if nplanes > 1 and nchannels > 1:
+        raise RuntimeError("ISXD files only support multi-plane or multi-channel data, but not both. " 
+                           "Please review input ops and ensure either nplanes >= 1 OR nchannels >= 1.")
 
     # open all binary files for writing
     ops1, file_list, reg_file, reg_file_chan2 = utils.find_files_open_binaries(ops1)
     iall = 0
-    for j in range(ops1[0]["nplanes"]):
+    for j in range(nplanes):
         ops1[j]["nframes_per_folder"] = np.zeros(len(file_list), np.int32)
-    ik = 0
-
+    
     for ifile, fname in enumerate(file_list):
         f = isx.Movie.read(fname)
-        # The following two lines break multiplane support
-        # nplanes = 1  #f.shape[1]
-        # nchannels = 1  #f.shape[2]
         nframes = f.timing.num_samples
         iblocks = np.arange(0, nframes, ops1[0]["batch_size"])
         if iblocks[-1] < nframes:
             iblocks = np.append(iblocks, nframes)
 
-        # data = nframes x nplanes x nchannels x pixels x pixels
+        # data = nframes x width x height x (nplanes OR nchannels)
         if nchannels > 1:
             nfunc = ops1[0]["functional_chan"] - 1
         else:
@@ -64,36 +63,50 @@ def isxd_to_binary(ops):
             offset = iblocks[ichunk + 1]
             im = np.array([f.get_frame_data(x) for x in np.arange(onset, offset)])
             im2mean = im.mean(axis=0).astype(np.float32) / len(iblocks)
-            for ichan in range(nchannels):
-                nframes = im.shape[0]
-                for j in range(0, nplanes):
-                    i0 = nchannels * ((j) % nplanes)
-                    im2write =  im[np.arange(int(i0) + nfunc, nframes, ncp), :, :]
 
-                    if iall == 0:
-                        ops1[j]["meanImg"] = np.zeros((im.shape[1], im.shape[2]),
-                                                      np.float32)
-                        if nchannels > 1:
-                            ops1[j]["meanImg_chan2"] = np.zeros(
-                                (im.shape[1], im.shape[2]), np.float32)
-                        ops1[j]["nframes"] = 0
+            if iall == 0:
+                for j in range(nplanes):
+                    ops1[j]["meanImg"] = np.zeros((im.shape[1], im.shape[2]),
+                                                np.float32)
+                    if nchannels > 1:
+                        ops1[j]["meanImg_chan2"] = np.zeros(
+                            (im.shape[1], im.shape[2]), np.float32)
+                    ops1[j]["nframes"] = 0
+
+            if nchannels > 1:
+                for ichan in range(nchannels):
+                    nframes = im.shape[0]
+                    i0 = (ichan) % nplanes
+                    im2write =  im[np.arange(int(i0), nframes, nchannels), :, :]
+
                     if ichan == nfunc:
-                        ops1[j]["meanImg"] += np.squeeze(im2mean)
+                        ops1[0]["meanImg"] += np.squeeze(im2mean)
                         reg_file[j].write(
                             bytearray(im2write[:].astype("int16")))
                     else:
-                        ops1[j]["meanImg_chan2"] += np.squeeze(im2mean)
+                        ops1[0]["meanImg_chan2"] += np.squeeze(im2mean)
                         reg_file_chan2[j].write(
                             bytearray(im2write[:].astype("int16")))
 
+                    ops1[0]["nframes"] += im2write.shape[0]
+                    ops1[0]["nframes_per_folder"][ifile] += im2write.shape[0]
+            elif nplanes > 1:
+                nframes = im.shape[0]
+                for j in range(0, nplanes):
+                    i0 = (j) % nplanes
+                    im2write =  im[np.arange(int(i0), nframes, nplanes), :, :]
+
+                    ops1[j]["meanImg"] += np.squeeze(im2mean)
+                    reg_file[j].write(
+                        bytearray(im2write[:].astype("int16")))
+
                     ops1[j]["nframes"] += im2write.shape[0]
                     ops1[j]["nframes_per_folder"][ifile] += im2write.shape[0]
-            ik += nframes
+
             iall += nframes
 
     # write ops files
     do_registration = ops1[0]["do_registration"]
-    do_nonrigid = ops1[0]["nonrigid"]
     for ops in ops1:
         ops["Ly"] = im.shape[1]
         ops["Lx"] = im.shape[2]

--- a/suite2p/io/isxd.py
+++ b/suite2p/io/isxd.py
@@ -34,6 +34,9 @@ def isxd_to_binary(ops):
     # the following should be taken from the metadata and not needed but the files are initialized before...
     nplanes = ops1[0]["nplanes"]
     nchannels = ops1[0]["nchannels"]
+    ncp = nplanes * nchannels
+    nfunc = ops1[0]["functional_chan"] - 1 if nchannels > 1 else 0
+
     # open all binary files for writing
     ops1, file_list, reg_file, reg_file_chan2 = utils.find_files_open_binaries(ops1)
     iall = 0
@@ -63,8 +66,12 @@ def isxd_to_binary(ops):
             im2mean = im.mean(axis=0).astype(np.float32) / len(iblocks)
             for ichan in range(nchannels):
                 nframes = im.shape[0]
-                im2write = im[:]
+                # im2write = im[:]
                 for j in range(0, nplanes):
+                    i0 = nchannels * ((j) % nplanes)
+                    # logger.info(f"frame indices for plane: {np.arange(int(i0) + nfunc, nframes, ncp)}")
+                    im2write =  im[np.arange(int(i0) + nfunc, nframes, ncp), :, :]
+
                     if iall == 0:
                         ops1[j]["meanImg"] = np.zeros((im.shape[1], im.shape[2]),
                                                       np.float32)

--- a/suite2p/io/isxd.py
+++ b/suite2p/io/isxd.py
@@ -43,9 +43,8 @@ def isxd_to_binary(ops):
 
     for ifile, fname in enumerate(file_list):
         f = isx.Movie.read(fname)
-        # The following two lines break multiplane support
-        # nplanes = 1  #f.shape[1]
-        # nchannels = 1  #f.shape[2]
+        nplanes = 1  #f.shape[1]
+        nchannels = 1  #f.shape[2]
         nframes = f.timing.num_samples
         iblocks = np.arange(0, nframes, ops1[0]["batch_size"])
         if iblocks[-1] < nframes:

--- a/suite2p/io/isxd.py
+++ b/suite2p/io/isxd.py
@@ -66,10 +66,8 @@ def isxd_to_binary(ops):
             im2mean = im.mean(axis=0).astype(np.float32) / len(iblocks)
             for ichan in range(nchannels):
                 nframes = im.shape[0]
-                # im2write = im[:]
                 for j in range(0, nplanes):
                     i0 = nchannels * ((j) % nplanes)
-                    # logger.info(f"frame indices for plane: {np.arange(int(i0) + nfunc, nframes, ncp)}")
                     im2write =  im[np.arange(int(i0) + nfunc, nframes, ncp), :, :]
 
                     if iall == 0:

--- a/suite2p/io/isxd.py
+++ b/suite2p/io/isxd.py
@@ -90,7 +90,7 @@ def isxd_to_binary(ops):
 
                     ops1[0]["nframes"] += im2write.shape[0]
                     ops1[0]["nframes_per_folder"][ifile] += im2write.shape[0]
-            elif nplanes > 1:
+            else:
                 nframes = im.shape[0]
                 for j in range(0, nplanes):
                     i0 = (j) % nplanes

--- a/suite2p/io/save.py
+++ b/suite2p/io/save.py
@@ -178,7 +178,7 @@ def combined(save_folder, save=True):
                 redcell = np.concatenate((redcell, redcell0))
         ii += 1
         print("appended plane %d to combined view" % k)
-    print(meanImg_chan2.shape)
+    # print(meanImg_chan2.shape)
     ops["meanImg"] = meanImg
     ops["meanImgE"] = meanImgE
     if ops["nchannels"] > 1:

--- a/suite2p/io/save.py
+++ b/suite2p/io/save.py
@@ -178,7 +178,7 @@ def combined(save_folder, save=True):
                 redcell = np.concatenate((redcell, redcell0))
         ii += 1
         print("appended plane %d to combined view" % k)
-    # print(meanImg_chan2.shape)
+    print(meanImg_chan2.shape)
     ops["meanImg"] = meanImg
     ops["meanImgE"] = meanImgE
     if ops["nchannels"] > 1:

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -339,10 +339,10 @@ def run_plane(ops, ops_path=None, stat=None):
     twoc = ops["nchannels"] > 1
     with io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file, n_frames=n_frames, write=True) \
             if raw else null as f_raw, \
-         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file, n_frames=n_frames, write=True) as f_reg, \
+         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file, n_frames=n_frames) as f_reg, \
          io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file_chan2, n_frames=n_frames, write=True) \
             if raw and twoc else null as f_raw_chan2,\
-         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file_chan2, n_frames=n_frames, write=True) \
+         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file_chan2, n_frames=n_frames) \
             if twoc else null as f_reg_chan2:
 
         ops = pipeline(f_reg, f_raw, f_reg_chan2, f_raw_chan2, run_registration, ops,

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -339,10 +339,10 @@ def run_plane(ops, ops_path=None, stat=None):
     twoc = ops["nchannels"] > 1
     with io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file, n_frames=n_frames, write=True) \
             if raw else null as f_raw, \
-         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file, n_frames=n_frames) as f_reg, \
+         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file, n_frames=n_frames, write=True) as f_reg, \
          io.BinaryFile(Ly=Ly, Lx=Lx, filename=raw_file_chan2, n_frames=n_frames, write=True) \
             if raw and twoc else null as f_raw_chan2,\
-         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file_chan2, n_frames=n_frames) \
+         io.BinaryFile(Ly=Ly, Lx=Lx, filename=reg_file_chan2, n_frames=n_frames, write=True) \
             if twoc else null as f_reg_chan2:
 
         ops = pipeline(f_reg, f_raw, f_reg_chan2, f_raw_chan2, run_registration, ops,

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -134,11 +134,14 @@ def pipeline(f_reg, f_raw=None, f_reg_chan2=None, f_raw_chan2=None,
         print("----------- Total %0.2f sec" % plane_times["registration"])
         n_frames, Ly, Lx = f_reg.shape
 
+        print(f"-----------n_frames, Ly, Lx: {n_frames, Ly, Lx}")
+
         if ops["two_step_registration"] and ops["keep_movie_raw"]:
             print("----------- REGISTRATION STEP 2")
             print("(making mean image (excluding bad frames)")
             nsamps = min(n_frames, 1000)
             inds = np.linspace(0, n_frames, 1 + nsamps).astype(np.int64)[:-1]
+            print(f"-----------inds, nsamps: {inds, nsamps}")
             if align_by_chan2:
                 refImg = f_reg_chan2[inds].astype(np.float32).mean(axis=0)
             else:

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -134,14 +134,11 @@ def pipeline(f_reg, f_raw=None, f_reg_chan2=None, f_raw_chan2=None,
         print("----------- Total %0.2f sec" % plane_times["registration"])
         n_frames, Ly, Lx = f_reg.shape
 
-        print(f"-----------n_frames, Ly, Lx: {n_frames, Ly, Lx}")
-
         if ops["two_step_registration"] and ops["keep_movie_raw"]:
             print("----------- REGISTRATION STEP 2")
             print("(making mean image (excluding bad frames)")
             nsamps = min(n_frames, 1000)
             inds = np.linspace(0, n_frames, 1 + nsamps).astype(np.int64)[:-1]
-            print(f"-----------inds, nsamps: {inds, nsamps}")
             if align_by_chan2:
                 refImg = f_reg_chan2[inds].astype(np.float32).mean(axis=0)
             else:


### PR DESCRIPTION
  # Description
  
  Fix a bug with isxd to binary conversion for multiplane files. For some reason the number of planes and channels is reset to one while converting each plane to binary format. This causes downstream errors processing each plane in the suite2p pipeline.


Note: Github checks are failing, but will be fixed once this fork is synced upstream.
  
  # Testing

 See related pr: https://github.com/inscopix/ideas-toolbox-suite2p-internal/pull/41